### PR TITLE
Use npm-style "license" metadata property

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,7 @@
   "bugs": {
     "url": "https://github.com/jonschlinkert/longest/issues"
   },
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/jonschlinkert/longest/blob/master/LICENSE"
-  },
+  "license": "MIT",
   "files": [
     "index.js"
   ],


### PR DESCRIPTION
Oh no! Not the licensing guy again!

Again, thanks so much for this package. I only found the old Ruby-style "licenses" property because I use the software. (It's in uglify-js' dependency tree via cliui and center-align).

I see @shinnn is a collaborator on this package. Good company :-)

Best,

K
